### PR TITLE
fix: using wrong `packageVersion` for the update command

### DIFF
--- a/packages/fluttium_cli/lib/src/commands/update_command.dart
+++ b/packages/fluttium_cli/lib/src/commands/update_command.dart
@@ -1,6 +1,7 @@
 import 'package:args/command_runner.dart';
 import 'package:fluttium_cli/src/command_runner.dart';
-import 'package:mason/mason.dart';
+import 'package:fluttium_cli/src/version.dart';
+import 'package:mason/mason.dart' hide packageVersion;
 import 'package:pub_updater/pub_updater.dart';
 
 /// {@template update_command}

--- a/packages/fluttium_cli/test/src/commands/update_command_test.dart
+++ b/packages/fluttium_cli/test/src/commands/update_command_test.dart
@@ -2,7 +2,8 @@ import 'dart:io';
 
 import 'package:fluttium_cli/src/command_runner.dart';
 import 'package:fluttium_cli/src/commands/commands.dart';
-import 'package:mason/mason.dart';
+import 'package:fluttium_cli/src/version.dart';
+import 'package:mason/mason.dart' hide packageVersion;
 import 'package:mocktail/mocktail.dart';
 import 'package:pub_updater/pub_updater.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READ**

## Description

It was using the `mason` exported `packageVersion` instead of the local one`.

Closes #16 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
