### PR TITLE
feat(fluttium_runner): add proper error output when the driver does not attach correctly

### DIFF
--- a/packages/fluttium_runner/lib/src/fluttium_runner.dart
+++ b/packages/fluttium_runner/lib/src/fluttium_runner.dart
@@ -209,21 +209,21 @@ class FluttiumRunner {
       workingDirectory: projectDirectory.path,
     );
 
-    var isCompleted = false;
+    var isAttached = false;
     final buffer = StringBuffer();
     _process?.stdout.listen((event) async {
       final data = utf8.decode(event).trim();
       buffer.write(data);
 
       // Skip until we see the first line of the test output.
-      if (!isCompleted &&
+      if (!isAttached &&
           data.startsWith(RegExp(r'^[I/]*flutter[\s*\(\s*\d+\)]*: '))) {
         startingUpTestDriver.complete();
-        isCompleted = true;
+        isAttached = true;
       }
 
       // Skip until the driver is ready.
-      if (!isCompleted) return;
+      if (!isAttached) return;
 
       final regex = RegExp('fluttium:(start|fail|done|screenshot):(.*?);');
       final matches = regex.allMatches(buffer.toString());
@@ -285,15 +285,15 @@ class FluttiumRunner {
     // Wait for the process to exit, and then clean up the project.
     await _process!.exitCode;
     _process = null;
-    await quit();
 
-    if (stderrBuffer.isNotEmpty) {
-      _logger
-        ..detail('Received the following information on stderr:')
-        ..detail(stderrBuffer.toString());
-    } else {
-      _logger.detail('No information received on stderr.');
+    // If it exited without correctly attaching to the application, we
+    // output the errors.
+    if (!isAttached) {
+      startingUpTestDriver.fail('Failed to start test driver');
+      _logger.err(stderrBuffer.toString());
     }
+
+    await quit();
   }
 
   /// Restart the runner and it's driver.


### PR DESCRIPTION

## Status

**READY**

## Description

Add proper error output when the driver does not attach correctly:

<img width="827" alt="image" src="https://user-images.githubusercontent.com/15887627/195863413-10577277-aa92-4aef-82ac-a28c9c1dcb87.png">


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
