### PR TITLE
refactor: use `Logger` instead of `print()` for CLI usage prompt

### DIFF
--- a/packages/fluttium_cli/lib/src/command_runner.dart
+++ b/packages/fluttium_cli/lib/src/command_runner.dart
@@ -51,6 +51,9 @@ class FluttiumCommandRunner extends CommandRunner<int> {
   final ProcessManager _process;
 
   @override
+  void printUsage() => _logger.info(usage);
+
+  @override
   Future<int> run(Iterable<String> args) async {
     try {
       final topLevelResults = parse(args);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

READY

## Description

When doing `dart test`, the usage message of commands is `print()`ed. This is undesirable and I think it's better to use `Logger` for this, which can be mocked.

**Before**
```
$ dart test
00:00 +0: test/ensure_build_test.dart: (suite)
  Skip: Should only be run during pull request. Verifies if version file is updated.
00:00 +6 ~1: test/src/command_runner_test.dart: FluttiumCommandRunner --verbose enables verbose logging
Fluttium, a user flow testing tool for Flutter.

Usage: fluttium <command> [arguments]

Global options:
-h, --help            Print this usage information.
-v, --version         Print the current version.
    --[no-]verbose    Noisy logging, including all shell commands executed.

Available commands:
  create   Create a FluttiumFlow test.
  test     Run a FluttiumFlow test.
  update   Update the CLI.

Run "fluttium help <command>" for more information about a command.
00:00 +7 ~1: test/src/command_runner_test.dart: FluttiumCommandRunner --verbose enables verbose logging for sub commands
Run a FluttiumFlow test.

Usage: fluttium test <flow.yaml>
-h, --help          Print this usage information.
-w, --[no-]watch    Watch for file changes.
-d, --device-id     Target device id or name (prefixes allowed).
    --flavor        Build a custom app flavor as defined by platform-specific build setup.
                    This will be passed to the --flavor option of flutter run.
-t, --target        The main entry-point file of the application, as run on the device.
                    (defaults to "lib/main.dart")

Run "fluttium help" to see global options.
00:00 +33 ~1: All tests passed!
```

**After**
```
$ dart test
00:00 +0: test/ensure_build_test.dart: (suite)
  Skip: Should only be run during pull request. Verifies if version file is updated.
00:00 +7 ~1: test/src/command_runner_test.dart: FluttiumCommandRunner --verbose enables verbose logging for sub commands
Run a FluttiumFlow test.

Usage: fluttium test <flow.yaml>
-h, --help          Print this usage information.
-w, --[no-]watch    Watch for file changes.
-d, --device-id     Target device id or name (prefixes allowed).
    --flavor        Build a custom app flavor as defined by platform-specific build setup.
                    This will be passed to the --flavor option of flutter run.
-t, --target        The main entry-point file of the application, as run on the device.
                    (defaults to "lib/main.dart")

Run "fluttium help" to see global options.
00:00 +33 ~1: All tests passed!
```

You might want to do the same for subcommand as well. I did that but some tests broke and I don't have time to fix them :(

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
