### PR TITLE
fix(fluttium_runner): use multi-line string to safely escape patterns for actions

### DIFF
--- a/packages/fluttium_runner/lib/src/fluttium_runner.dart
+++ b/packages/fluttium_runner/lib/src/fluttium_runner.dart
@@ -93,24 +93,25 @@ class FluttiumRunner {
   }
 
   void _convertFlowToVars() {
-    String sanitize(String text) => text.replaceAll("'", r"\'");
+    String sanitizeText(String text) => text.replaceAll("'", r"\'");
+    String sanitizeRegExp(String text) => text.replaceAll("'''", r"\'''");
 
     _vars.addAll({
-      'flowDescription': sanitize(flow!.description),
+      'flowDescription': sanitizeText(flow!.description),
       'flowSteps': flow!.steps
           .map((e) {
-            final text = sanitize(e.text);
+            final text = sanitizeRegExp(e.text);
             switch (e.action) {
               case FluttiumAction.expectVisible:
-                return "await tester.expectVisible(r'$text');";
+                return "await tester.expectVisible(r'''$text''');";
               case FluttiumAction.expectNotVisible:
-                return "await tester.expectNotVisible(r'$text');";
+                return "await tester.expectNotVisible(r'''$text''');";
               case FluttiumAction.tapOn:
-                return "await tester.tapOn(r'$text');";
+                return "await tester.tapOn(r'''$text''');";
               case FluttiumAction.inputText:
-                return "await tester.inputText(r'$text');";
+                return "await tester.inputText(r'''$text''');";
               case FluttiumAction.takeScreenshot:
-                return "await tester.takeScreenshot(r'$text');";
+                return "await tester.takeScreenshot(r'''$text''');";
             }
           })
           .map((e) => {'step': e})


### PR DESCRIPTION
Use double quotes on FluttiumActions to avoid a compilation error when using a single quotes on Flow yaml file

Related issue: #87 

## Status

**READY**

## Description

The sanitizer prefix every single quote with a backslash. 
But in FluttiumActions we use raw text, and this backslash will not act as expected anymore. 

I replace single quotes inside Action by double quotes to prevent build failed, and allow using single quotes inside Flows

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
