### PR TITLE
fix(fluttium_runner): use multi-line string to safely escape patterns for actions

### DIFF
--- a/packages/fluttium_runner/lib/src/fluttium_runner.dart
+++ b/packages/fluttium_runner/lib/src/fluttium_runner.dart
@@ -135,15 +135,15 @@ class FluttiumRunner {
             final text = sanitizeRegExp(e.text);
             switch (e.action) {
               case FluttiumAction.expectVisible:
-                return "await worker.expectVisible(r'$text');";
+                return "await worker.expectVisible(r'''$text''');";
               case FluttiumAction.expectNotVisible:
-                return "await worker.expectNotVisible(r'$text');";
+                return "await worker.expectNotVisible(r'''$text''');";
               case FluttiumAction.tapOn:
-                return "await worker.tapOn(r'$text');";
+                return "await worker.tapOn(r'''$text''');";
               case FluttiumAction.inputText:
-                return "await worker.inputText(r'$text');";
+                return "await worker.inputText(r'''$text''');";
               case FluttiumAction.takeScreenshot:
-                return "await worker.takeScreenshot(r'$text');";
+                return "await worker.takeScreenshot(r'''$text''');";
             }
           })
           .map((e) => {'step': e})

--- a/packages/fluttium_runner/test/src/fluttium_runner_test.dart
+++ b/packages/fluttium_runner/test/src/fluttium_runner_test.dart
@@ -41,11 +41,11 @@ void main() {
       'project_name': 'project_name',
       'flow_description': 'test',
       'flow_steps': [
-        {'step': "await worker.tapOn(r'Text');"},
-        {'step': "await worker.expectVisible(r'Text');"},
-        {'step': "await worker.expectNotVisible(r'Text');"},
-        {'step': "await worker.inputText(r'Text');"},
-        {'step': "await worker.takeScreenshot(r'Text');"}
+        {'step': "await worker.tapOn(r'''Text''');"},
+        {'step': "await worker.expectVisible(r'''Text''');"},
+        {'step': "await worker.expectNotVisible(r'''Text''');"},
+        {'step': "await worker.inputText(r'''Text''');"},
+        {'step': "await worker.takeScreenshot(r'''Text''');"}
       ]
     };
 


### PR DESCRIPTION
Me again, with the use of multiline notation to avoid a compilation error when using a single quotes on Flow yaml file.

I think a refactor remove my previous fix

Related issue: #87 
Related PR: #88 

## Status

**READY**

## Description

Multi-line notation (with 3 `'` or 3 `"`) allow us to sanitize text patterns with backslashes. 
The main issue was to be able to use single or double quotes on the YAML file to perform actions, like:
```yaml
- expectVisible: "Thithip's awesome app!"
```

Unfortunately a refactor on commit e200a8a61e117060c06907ec5629173d09cadef7 remove my previous fix.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
