### PR TITLE
feat: implement a `wait` action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ coverage
 
 !.vscode/launch.json
 !.idea/runConfigurations/
+.fvm/flutter_sdk
+.fvm/fvm_config.json

--- a/bricks/fluttium_driver/__brick__/.{{flow_description.snakeCase()}}_driver.dart
+++ b/bricks/fluttium_driver/__brick__/.{{flow_description.snakeCase()}}_driver.dart
@@ -63,6 +63,16 @@ class FluttiumWorker {
 
   RenderObject get renderObject => binding.renderViewElement!.renderObject!;
 
+  Future<void> wait(String text) async {
+    await manager.start();
+    try {
+      final node = await Future.delayed(Duration(seconds: num.tryParse(text).toInt()))
+      await manager.done();
+    } catch (err) {
+      await manager.fail();
+    }
+  }
+
   Future<void> tapOn(String text) async {
     await manager.start();
     try {

--- a/bricks/fluttium_driver/__brick__/.{{flow_description.snakeCase()}}_driver.dart
+++ b/bricks/fluttium_driver/__brick__/.{{flow_description.snakeCase()}}_driver.dart
@@ -66,6 +66,20 @@ class FluttiumWorker {
   Future<void> wait(String text) async {
     await manager.start();
     try {
+      Duration duration = Duration();
+      int valueInt = num.parse(text.split(" ").first);
+      String typeOfDuration = text.split(" ").last;
+      if(typeOfDuration.contains("microsecond")){
+        duration = Duration(microseconds: valueInt)
+      }else if(typeOfDuration.contains("millisecond")){
+        duration = Duration(milliseconds: valueInt)
+      }else if(typeOfDuration.contains("second")){
+        duration = Duration(seconds: valueInt)
+      }else if(typeOfDuration.contains("minute")){
+        duration = Duration(minutes: valueInt)
+      }else if(typeOfDuration.contains("hour")){
+        duration = Duration(hours: valueInt)
+      }
       final node = await Future.delayed(Duration(seconds: num.tryParse(text).toInt()))
       await manager.done();
     } catch (err) {

--- a/bricks/fluttium_driver/__brick__/.{{flow_description.snakeCase()}}_driver.dart
+++ b/bricks/fluttium_driver/__brick__/.{{flow_description.snakeCase()}}_driver.dart
@@ -80,7 +80,7 @@ class FluttiumWorker {
       }else if(typeOfDuration.contains("hour")){
         duration = Duration(hours: valueInt)
       }
-      final node = await Future.delayed(Duration(seconds: num.tryParse(text).toInt()))
+      final node = await Future.delayed(duration)
       await manager.done();
     } catch (err) {
       await manager.fail();

--- a/packages/fluttium_cli/lib/src/commands/test_command.dart
+++ b/packages/fluttium_cli/lib/src/commands/test_command.dart
@@ -252,6 +252,9 @@ Multiple defines can be passed by repeating "--dart-define" multiple times.''',
             case FluttiumAction.takeScreenshot:
               actionDescription = 'Screenshot "${step.text}"';
               break;
+            case FluttiumAction.wait:
+              actionDescription = 'Wait "${step.text}"';
+              break;
           }
 
           if (i < stepStates.length) {

--- a/packages/fluttium_cli/test/src/commands/test_command_test.dart
+++ b/packages/fluttium_cli/test/src/commands/test_command_test.dart
@@ -625,6 +625,7 @@ void main() {
             FluttiumStep(FluttiumAction.tapOn, text: 'text'),
             FluttiumStep(FluttiumAction.inputText, text: 'text'),
             FluttiumStep(FluttiumAction.takeScreenshot, text: 'text'),
+            FluttiumStep(FluttiumAction.wait, text: 'text'),
           ]);
 
           renderer(flow, []);

--- a/packages/fluttium_flow/lib/src/fluttium_action.dart
+++ b/packages/fluttium_flow/lib/src/fluttium_action.dart
@@ -12,6 +12,9 @@ enum FluttiumAction {
   /// Input the given text.
   inputText,
 
+  /// Make a pause.
+  wait,
+
   /// Take a screenshot with the given name.
   takeScreenshot;
 
@@ -28,6 +31,8 @@ enum FluttiumAction {
         return FluttiumAction.inputText;
       case 'takeScreenshot':
         return FluttiumAction.takeScreenshot;
+      case 'wait':
+        return FluttiumAction.wait;
       default:
         throw UnimplementedError('$action is not implemented');
     }

--- a/packages/fluttium_runner/lib/src/fluttium_runner.dart
+++ b/packages/fluttium_runner/lib/src/fluttium_runner.dart
@@ -127,7 +127,7 @@ class FluttiumRunner {
   void _convertFlowToVars() {
     String sanitizeText(String text) => text.replaceAll("'", r"\'");
     String sanitizeRegExp(String text) => text.replaceAll("'''", r"\'''");
-
+    
     _vars.addAll({
       'flow_description': sanitizeText(flow!.description),
       'flow_steps': flow!.steps
@@ -144,6 +144,8 @@ class FluttiumRunner {
                 return "await worker.inputText(r'$text');";
               case FluttiumAction.takeScreenshot:
                 return "await worker.takeScreenshot(r'$text');";
+              case FluttiumAction.wait:
+                return "await worker.wait(r'$text')";
             }
           })
           .map((e) => {'step': e})

--- a/packages/fluttium_runner/test/src/fluttium_runner_test.dart
+++ b/packages/fluttium_runner/test/src/fluttium_runner_test.dart
@@ -45,6 +45,7 @@ void main() {
         {'step': "await worker.expectVisible(r'Text');"},
         {'step': "await worker.expectNotVisible(r'Text');"},
         {'step': "await worker.inputText(r'Text');"},
+        {'step': "await worker.wait(r'Text');"},
         {'step': "await worker.takeScreenshot(r'Text');"}
       ]
     };
@@ -84,6 +85,7 @@ description: test
 - expectNotVisible: "Text"
 - inputText: "Text"
 - takeScreenshot: "Text"
+- wait: "Text"
 ''');
       when(() => flowFile.path).thenReturn('flow.yaml');
 


### PR DESCRIPTION
Addition of a wait option, some apps that take a few seconds to enter the splash may not work tests without this action

## Status

**READY**

## Description

Add new action label wait
`- wait: 1 second` // wait 1 second to make next action
 using plain english durations
 exemples:
 ```
wait: 1 microsecond
wait: 1 millisecond
wait: 1 second
wait: 1 minute
wait: 1 hour
```


## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
